### PR TITLE
Fix build errors and running out of free space

### DIFF
--- a/Custom Definitions.event
+++ b/Custom Definitions.event
@@ -1,8 +1,13 @@
+#ifndef VBABT_DEFINITIONS
+#define VBABT_DEFINITIONS
 
+#define FreeSpace        0xB2A610
+#define FreeSpaceEnd     0xC00000
 
-#define FreeSpace 0xb2a610
-#define EndOfFreeSpace 0xC00000
-#define FreeSpaceBLRange 0x1c1ec0
+#define FreeSpace2       0xEFB2E0
+#define FreeSpace2End    0xFE0000
+
+#define FreeSpaceBLRange 0x1C1EC0
 
 #define ChapterTileset(chapter, object, palette, config) "PUSH; ORG 0x8b0890 + (148* chapter) + 4; SHORT object; BYTE palette config; POP"
 #define ChapterTileAnims(chapter, anim1, anim2) "PUSH; ORG 0x8b0890 + (148* chapter) + 9; BYTE anim1 anim2; POP"
@@ -246,3 +251,5 @@
 #define WTYPE_LIGHT    0x06
 #define WTYPE_ELDER    0x07
 #define WTYPE_DARK     0x07
+
+#endif // VBABT_DEFINITIONS

--- a/Events/Endgame.event
+++ b/Events/Endgame.event
@@ -105,7 +105,7 @@ Tutorial:
 WORD $00
 
 TrapData1:
-KillerBallista(15,11)
+BLST [15, 11] KillerBallista
 ENDTRAP
 ALIGN 4
 

--- a/ROM Buildfile.event
+++ b/ROM Buildfile.event
@@ -1,42 +1,49 @@
 #ifdef _FE8_
     #include "EAstdlib.event"
     #include "Custom Definitions.event"
-
+	
     ORG FreeSpace
-    PROTECT EndOfFreeSpace // Prevent overflow of data.
-    //Text first for Text ID definitions
+    PROTECT FreeSpaceEnd // Prevent overflow of data.
+	
+	// FREE SPACE #1:
+	// Text, Mugs, Tables, Wizardry, Events
+
+    // Text first for Text ID definitions
     #include "Text/Install Text Data.event"
     ALIGN 4
-    MESSAGE Used text space ends at currentOffset
-
-    //Graphics
-    #include "Graphics/Master Graphics Installer.event"
+    MESSAGE Used text space ends at CURRENTOFFSET
+	
+	// Mugs, before tables because of definitions shenanigans
     ALIGN 4
     #include "Mugs/Mug Installer.event"
 
-    //CSV tables
+    // CSV tables
     #include "Tables/Table Installer.event"
-    MESSAGE Used table space ends at currentOffset
+    MESSAGE Used table space ends at CURRENTOFFSET
 
-    //Engine Hacks
+    // Engine Hacks
     #include "Engine Hacks/_MasterHackInstaller.event"
-    MESSAGE Used hax space ends at currentOffset
-
-    //Events
+    MESSAGE Used hax space ends at CURRENTOFFSET
+	
+    // Events
     #include "Events/Master Events Installer.event"
     #include "Events/World Map Events Installer.event"
 
-    //Maps
+	ORG FreeSpace2
+	PROTECT FreeSpace2End
+	
+	// FREE SPACE #2:
+	// Graphics (except mugs, see above), Maps
+	
+    // Graphics
+    #include "Graphics/Master Graphics Installer.event"
+    #include "Battle Palettes/Palette Setup.event"
+
+    // Maps
     #include "Maps/FixedValni.event"
     #include "Maps/Cave Tileset/Cave Tileset Installer.event"
     #include "Maps/FE6 Snow Tileset/FE6 Snow Installer.event"
     #include "Maps/Master Map Installer.event"
-
-    //Palettes
-    #include "Battle Palettes/Palette Setup.event"
-
-    MESSAGE Used free space ends at currentOffset
-    MESSAGE Proc_Counter
 #else
     ERROR You are not assembling FE8 events!
 #endif


### PR DESCRIPTION
    In File Endgame.event, Line 108, Column 1: Incorrect parameters in raw BLST.
    In File SnowAnimation.event, Line 45, Column 1: Trying to write data to protected area

Those errors in particular.

The first one is because for many the `KillerBallista(x, y)` macro is wrong. Fixed by replacing it by the raw code, which imo isn't any less readable anyway.

The second one is directly related to the free space issue. By the time we got to inserting the snow tileset we reached offset `C00000`, which was protected to be able to diagnose getting past free space. Of course, `PROTECT` was broken in ColorzCore until fairly recently so people with an older version wouldn't have gotten any errors.

Fixed free space by splitting it into two. First one has Text, Mugs, Tables, Wizardy and Events; Second one has non-mug Graphics and maps. Both ranges are protected properly.